### PR TITLE
"Go to profile" does not redirect to USAJOBS

### DIFF
--- a/assets/js/backbone/apps/admin/templates/admin_task_template.html
+++ b/assets/js/backbone/apps/admin/templates/admin_task_template.html
@@ -8,11 +8,6 @@
   </div>
 </div>
 <p class="back-link"><a id="task-back" href="<%- returnUrl %>"><i class="fas fa-chevron-circle-left"></i>Back</a></p>
-<a class="usajobs-nav__section-link usajobs-nav--openopps__section-link" href="https://usajobs.github.io/openopps-help/opportunity/opportunity-status/"  target="_blank" rel="noopener noreferrer" title="Help">
-  <span class="usajobs-nav--openopps__section">
-    <span class="fas fa-question-circle" title="Help"></span>Help
-  </span>
-</a>
 <h2><%- agency.name || community.communityName || 'Sitewide' %></h2>
 <h3 ><% if(cycleName) { %>Opportunities for <%-cycleName %> <% } else {%> Opportunities <% } %> </h3>
 <div class="usajobs-grid-full">

--- a/assets/js/backbone/apps/footer/templates/footer_template.html
+++ b/assets/js/backbone/apps/footer/templates/footer_template.html
@@ -13,9 +13,6 @@
 		</div>
 		<div class="usajobs-footer--openopps__col usajobs-footer--openopps__help">
 			<div class="usajobs-footer--openopps__contact-link">
-				<div class="usa-footer-search--intern-hide">
-					Visit our <a href="https://usajobs.github.io/openopps-help/" target="_blank">Help Center</a>
-				</div>
 			</div>
 		</div>
 		<div class="usajobs-footer--openopps__col usajobs-footer--openopps__contact">

--- a/assets/js/backbone/apps/nav/templates/nav_template.html
+++ b/assets/js/backbone/apps/nav/templates/nav_template.html
@@ -48,11 +48,6 @@
               <% } %>
             <% } %>
             <li class="usajobs-nav__menu-container usajobs-nav__menu-search desktop">
-                <a class="usajobs-nav__section-link usajobs-nav--openopps__section-link" href="https://usajobs.github.io/openopps-help/"  target="_blank" rel="noopener noreferrer" title="Help">
-                  <span class="usajobs-nav--openopps__section">
-                    <span class="fas fa-question-circle" title="Help"></span>Help
-                  </span>
-                </a>
               </li>
             <li class="usajobs-nav__menu-container usajobs-nav__menu-search desktop">
               <a class="usajobs-nav__section-link usajobs-nav--openopps__section-link menu-toggle toggle-two" href="/search" title="Search Opportunities">

--- a/assets/js/backbone/browse-app.js
+++ b/assets/js/backbone/browse-app.js
@@ -374,10 +374,10 @@ var BrowseRouter = Backbone.Router.extend({
         modalTitle: 'Please complete your profile.',
         modalBody: 'You have not selected your agency in your profile.',
         primary: {
-          text: loginGov ? 'Update profile at USAJOBS.gov' : 'Go to profile',
+          text: 'Go to profile',
           action: function () {
             this.modal.cleanup();
-            window.location = usajobsURL + '/Applicant/Profile/';
+            Backbone.history.navigate('/profile/' + window.cache.currentUser.id, { trigger: true });
           }.bind(this),
         },           
         secondary: {


### PR DESCRIPTION
Resolves https://github.com/chhsinnovation/openopps-platform/issues/8

Also removes some help pages links on the first page that led to USAJOBS (there are still some other links to USAJOBS elsewhere in the application)

Testing: After creating a new account and trying to create an opportunity, the following is displayed:
![image](https://user-images.githubusercontent.com/3781835/81114027-2fe3af00-8eef-11ea-9657-79e3b289a3f3.png)

After clicking "Go to profile", we go to the Open Opps profile, not to USAJOBS, and the user can add an agency.
![image](https://user-images.githubusercontent.com/3781835/81114055-3d993480-8eef-11ea-9159-6f6abc87966d.png)

