### PR TITLE
Adding a migration to remove federal series data and add CA data.

### DIFF
--- a/migrations/20200512000000-remove-fed-add-ca-series.js
+++ b/migrations/20200512000000-remove-fed-add-ca-series.js
@@ -1,0 +1,51 @@
+'use strict';
+
+var _ = require('lodash');
+var yaml = require('js-yaml');
+var fs = require('fs');
+
+
+var dbm;
+var type;
+var seed;
+
+/**
+  * We receive the dbmigrate dependency from dbmigrate initially.
+  * This enables us to not have to rely on NODE_PATH.
+  */
+exports.setup = function(options, seedLink) {
+  dbm = options.dbmigrate;
+  type = dbm.dataType;
+  seed = seedLink;
+};
+
+exports.up = function(db, callback) {
+  db.runSql(`
+    delete from tagentity where type = 'series' 
+  `, callback);
+
+  var tags = [];
+  var tagFile = 'tools/init-tag-data/series.yml';
+  if (fs.existsSync(tagFile)) {
+    var tagFileObjects = yaml.safeLoad(fs.readFileSync(tagFile).toString());
+    tags = _.map(tagFileObjects, function (item) {
+      return {
+        name: item.title + " (" + item.code + ")",
+        series: item.code,
+        title: item.title
+      }
+    });
+    tags.forEach(tag => {
+      var query = `insert into tagEntity("type", "name", "data", "createdAt", "updatedAt") select 'series', $1, $2, NOW(), NOW() where not exists (select id from tagEntity where name = $1 and type = 'series')`; 
+      db.runSql(query, [tag.name, JSON.stringify(tag)], callback);
+    });
+  }
+};
+
+exports.down = function(db) {
+  return null;
+};
+
+exports._meta = {
+  "version": 1
+};


### PR DESCRIPTION
Fixing #12 with a migration. #15 replaced the base data, but did nothing for a currently deployed version of the application. This adds a migration that removes all series data and repopulates the table with the california series data.